### PR TITLE
Mark item as purchased

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,7 +67,10 @@ export function App() {
 							/>
 						}
 					/>
-					<Route path="/list" element={<List data={data} />} />
+					<Route
+						path="/list"
+						element={<List data={data} listToken={listToken} />}
+					/>
 					<Route path="/add-item" element={<AddItem listToken={listToken} />} />
 				</Route>
 			</Routes>

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -5,6 +5,8 @@ import {
 	addDoc,
 	query,
 	getDocs,
+	doc,
+	updateDoc,
 } from 'firebase/firestore';
 import { getFutureDate } from '../utils';
 
@@ -70,12 +72,9 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem() {
-	/**
-	 * TODO: Fill this out so that it uses the correct Firestore function
-	 * to update an existing item. You'll need to figure out what arguments
-	 * this function must accept!
-	 */
+export async function updateItem(listId, itemId, { item }) {
+	const itemRef = doc(db, listId, itemId);
+	return await updateDoc(itemRef, item);
 }
 
 export async function deleteItem() {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -72,9 +72,16 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem(listId, itemId, { item }) {
+export async function updateItem(
+	listId,
+	itemId,
+	{ dateLastPurchased, totalPurchases },
+) {
 	const itemRef = doc(db, listId, itemId);
-	return await updateDoc(itemRef, item);
+	return await updateDoc(itemRef, {
+		dateLastPurchased,
+		totalPurchases,
+	});
 }
 
 export async function deleteItem() {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -72,16 +72,9 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem(
-	listId,
-	itemId,
-	{ dateLastPurchased, totalPurchases },
-) {
+export async function updateItem(listId, itemId, nextData) {
 	const itemRef = doc(db, listId, itemId);
-	return await updateDoc(itemRef, {
-		dateLastPurchased,
-		totalPurchases,
-	});
+	return await updateDoc(itemRef, nextData);
 }
 
 export async function deleteItem() {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,7 +3,10 @@ import { useState } from 'react';
 import { updateItem } from '../api';
 
 export function ListItem({ name, data, listToken }) {
-	const [isChecked, setIsChecked] = useState(false);
+	const initialChecked =
+		Date.now() - data.dateLastPurchased.toMillis() < 86400000;
+
+	const [isChecked, setIsChecked] = useState(initialChecked);
 
 	const itemData = {
 		id: data.id,
@@ -20,8 +23,6 @@ export function ListItem({ name, data, listToken }) {
 			updateItem(listToken, data.id, itemData);
 		}
 	};
-
-	console.log(isChecked, 'itemPurchased');
 
 	return (
 		<>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,22 +3,25 @@ import { useState } from 'react';
 import { updateItem } from '../api';
 
 export function ListItem({ name, data, listToken }) {
-	const [itemPurchased, setItemPurchased] = useState('');
+	const [isChecked, setIsChecked] = useState(false);
 
 	const itemData = {
 		id: data.id,
 		dateLastPurchased: new Date(),
-		totalPurchases: 1,
+		totalPurchases: data.totalPurchases + 1,
 	};
 
 	const handleSelect = (e) => {
-		let isChecked = e.target.checked;
+		let nextChecked = e.target.checked;
 
-		if (isChecked) {
-			setItemPurchased(itemData);
-			updateItem(listToken, data.id, itemPurchased);
+		// toggling isChecked based on checkbox state
+		setIsChecked(nextChecked);
+		if (nextChecked) {
+			updateItem(listToken, data.id, itemData);
 		}
 	};
+
+	console.log(isChecked, 'itemPurchased');
 
 	return (
 		<>
@@ -28,7 +31,7 @@ export function ListItem({ name, data, listToken }) {
 					type="checkbox"
 					id="listItem"
 					value={name}
-					checked={itemPurchased}
+					checked={isChecked}
 					onChange={handleSelect}
 				/>
 				<label htmlFor="listItem" className="ListItem-label">

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,10 +1,39 @@
 import './ListItem.css';
+import { useState } from 'react';
+// import { updateItem } from '../api';
 
-export function ListItem({ name }) {
+export function ListItem({ name, data, listToken }) {
+	const [itemPurchased, setItemPurchased] = useState('');
+
+	console.log(data, 'data');
+	console.log(itemPurchased, 'itemPurchased');
+
+	const itemData = {
+		id: data.id,
+		dateLastPurchased: new Date(),
+		totalPurchases: 1,
+	};
+
+	const handleSelect = (e) => {
+		let isChecked = e.target.checked;
+
+		if (isChecked) {
+			setItemPurchased(itemData);
+			// updateItem(listToken, itemPurchased)
+		}
+	};
+
 	return (
 		<>
 			<li className="ListItem">
-				<input type="checkbox" className="ListItem-checkbox" id="listItem" />
+				<input
+					className="ListItem-checkbox"
+					type="checkbox"
+					id="listItem"
+					value={name}
+					checked={itemPurchased}
+					onChange={handleSelect}
+				/>
 				<label htmlFor="listItem" className="ListItem-label">
 					{name}
 				</label>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,7 +4,7 @@ import { updateItem } from '../api';
 
 export function ListItem({ name, data, listToken }) {
 	const initialChecked =
-		Date.now() - data.dateLastPurchased.toMillis() < 86400000;
+		Date.now() - data.dateLastPurchased?.toMillis() < 86400000 || false;
 
 	const [isChecked, setIsChecked] = useState(initialChecked);
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -8,19 +8,18 @@ export function ListItem({ name, data, listToken }) {
 
 	const [isChecked, setIsChecked] = useState(initialChecked);
 
-	const itemData = {
-		id: data.id,
-		dateLastPurchased: new Date(),
-		totalPurchases: data.totalPurchases + 1,
-	};
-
 	const handleSelect = (e) => {
 		let nextChecked = e.target.checked;
 
 		// toggling isChecked based on checkbox state
 		setIsChecked(nextChecked);
 		if (nextChecked) {
-			updateItem(listToken, data.id, itemData);
+			const nextData = {
+				dateLastPurchased: new Date(),
+				totalPurchases: data.totalPurchases + 1,
+			};
+
+			updateItem(listToken, data.id, nextData);
 		}
 	};
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,14 @@
 import './ListItem.css';
 
 export function ListItem({ name }) {
-	return <li className="ListItem">{name}</li>;
+	return (
+		<>
+			<li className="ListItem">
+				<input type="checkbox" className="ListItem-checkbox" id="listItem" />
+				<label htmlFor="listItem" className="ListItem-label">
+					{name}
+				</label>
+			</li>
+		</>
+	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,12 +1,9 @@
 import './ListItem.css';
 import { useState } from 'react';
-// import { updateItem } from '../api';
+import { updateItem } from '../api';
 
 export function ListItem({ name, data, listToken }) {
 	const [itemPurchased, setItemPurchased] = useState('');
-
-	console.log(data, 'data');
-	console.log(itemPurchased, 'itemPurchased');
 
 	const itemData = {
 		id: data.id,
@@ -19,7 +16,7 @@ export function ListItem({ name, data, listToken }) {
 
 		if (isChecked) {
 			setItemPurchased(itemData);
-			// updateItem(listToken, itemPurchased)
+			updateItem(listToken, data.id, itemPurchased);
 		}
 	};
 

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,7 +1,7 @@
 import { ListItem } from '../components';
 import { useState } from 'react';
 
-export function List({ data }) {
+export function List({ data, listToken }) {
 	//set state
 	const [searchedItem, setSearchedItem] = useState('');
 	//filtering items searched
@@ -45,7 +45,14 @@ export function List({ data }) {
 					<p>It's not here!</p>
 				) : (
 					filteredItems.map((list) => {
-						return <ListItem name={list.name} key={list.id} />;
+						return (
+							<ListItem
+								name={list.name}
+								key={list.id}
+								data={list}
+								listToken={listToken}
+							/>
+						);
 					})
 				)}
 			</ul>


### PR DESCRIPTION
## Description

Users need a UI that allows them to mark the their items as purchased, so they can track what on their list they do and do not need to buy.

## Related Issue

Closes #8 

## Acceptance Criteria

- [X]  The ListItem component renders a checkbox with a semantic `<label>`
- [X]  Checking off the item in the UI also updates the `dateLastPurchased` and `totalPurchases` properties on the corresponding Firestore document
- [X]  The item is shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day). After 24 hours, the item unchecks itself so the user can buy it again.
- [X]  The `updateItem` function in `firebase.js` has been filled out, and sends updates to the firestore database when an item is checked or un-checked

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![List Page](https://user-images.githubusercontent.com/84824067/215871169-529d0be4-b4f2-4170-ac5f-dd04d6b2f8c4.png)

### After
<img width="622" alt="Screen Shot 2023-01-31 at 5 45 44 PM" src="https://user-images.githubusercontent.com/80288782/215901048-687ca943-364d-4d1f-af77-f9c1c08bf4a0.png">

## Testing Steps / QA Criteria
Checking a grocery item updates its dateLastPurchased and totalPurchases fields in Firebase. Once 24 hours since dateLastPurchased pass, the item is no longer checked. 