### PR TITLE
Estimated next purchase date

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -8,7 +8,7 @@ import {
 	doc,
 	updateDoc,
 } from 'firebase/firestore';
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 /**
  * Subscribe to changes on a specific list in the Firestore database (listId), and run a callback (handleSuccess) every time a change happens.

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -8,7 +8,7 @@ import {
 	doc,
 	updateDoc,
 } from 'firebase/firestore';
-import { getFutureDate, getDaysBetweenDates } from '../utils';
+import { getFutureDate } from '../utils';
 
 /**
  * Subscribe to changes on a specific list in the Firestore database (listId), and run a callback (handleSuccess) every time a change happens.

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -16,45 +16,7 @@ export function ListItem({ name, data, listToken }) {
 		// toggling isChecked based on checkbox state
 		setIsChecked(nextChecked);
 		if (nextChecked) {
-			const today = new Date();
-			const ONE_DAY_IN_MILLISECONDS = 86400000;
-			// if the item hasn't been purchased, compare today to the date of its creation else compare today to the day it was last purchased.
-			const timeSinceLastPurchase =
-				data.dateLastPurchased === null
-					? getDaysBetweenDates(today.getTime(), data.dateCreated.toMillis())
-					: getDaysBetweenDates(
-							today.getTime(),
-							data.dateLastPurchased.toMillis(),
-					  );
-			console.log(timeSinceLastPurchase);
-
-			//interval last time
-			const lastEstimatedInterval =
-				data.dateLastPurchased === null
-					? getDaysBetweenDates(
-							data.dateNextPurchased.toMillis(),
-							data.dateCreated.toMillis(),
-					  )
-					: getDaysBetweenDates(
-							data.dateNextPurchased.toMillis(),
-							data.dateLastPurchased.toMillis(),
-					  );
-
-			//use calculateEstimate to tell the time until next purchase
-			const daysUntilNextPurchase = calculateEstimate(
-				lastEstimatedInterval,
-				timeSinceLastPurchase,
-				data.totalPurchases + 1,
-			);
-
-			const nextData = {
-				dateLastPurchased: new Date(),
-				totalPurchases: data.totalPurchases + 1,
-				dateNextPurchased: new Date(
-					today.getTime() + daysUntilNextPurchase * ONE_DAY_IN_MILLISECONDS,
-				),
-			};
-
+			const nextData = createNextData(data);
 			updateItem(listToken, data.id, nextData);
 		}
 	};
@@ -76,4 +38,41 @@ export function ListItem({ name, data, listToken }) {
 			</li>
 		</>
 	);
+}
+
+function createNextData(data) {
+	const today = new Date();
+	const ONE_DAY_IN_MILLISECONDS = 86400000;
+	// if the item hasn't been purchased, compare today to the date of its creation, else compare today to the day it was last purchased.
+	const timeSinceLastPurchase =
+		data.dateLastPurchased === null
+			? getDaysBetweenDates(today.getTime(), data.dateCreated.toMillis())
+			: getDaysBetweenDates(today.getTime(), data.dateLastPurchased.toMillis());
+
+	//interval last time
+	const lastEstimatedInterval =
+		data.dateLastPurchased === null
+			? getDaysBetweenDates(
+					data.dateNextPurchased.toMillis(),
+					data.dateCreated.toMillis(),
+			  )
+			: getDaysBetweenDates(
+					data.dateNextPurchased.toMillis(),
+					data.dateLastPurchased.toMillis(),
+			  );
+
+	//use calculateEstimate to tell the time until next purchase
+	const daysUntilNextPurchase = calculateEstimate(
+		lastEstimatedInterval,
+		timeSinceLastPurchase,
+		data.totalPurchases + 1,
+	);
+
+	return {
+		dateLastPurchased: today,
+		totalPurchases: data.totalPurchases + 1,
+		dateNextPurchased: new Date(
+			today.getTime() + daysUntilNextPurchase * ONE_DAY_IN_MILLISECONDS,
+		),
+	};
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -16,50 +16,48 @@ export function ListItem({ name, data, listToken }) {
 		// toggling isChecked based on checkbox state
 		setIsChecked(nextChecked);
 		if (nextChecked) {
+			const today = new Date();
+			const ONE_DAY_IN_MILLISECONDS = 86400000;
+			// if the item hasn't been purchased, compare today to the date of its creation else compare today to the day it was last purchased.
+			const timeSinceLastPurchase =
+				data.dateLastPurchased === null
+					? getDaysBetweenDates(today.getTime(), data.dateCreated.toMillis())
+					: getDaysBetweenDates(
+							today.getTime(),
+							data.dateLastPurchased.toMillis(),
+					  );
+			console.log(timeSinceLastPurchase);
+
+			//interval last time
+			const lastEstimatedInterval =
+				data.dateLastPurchased === null
+					? getDaysBetweenDates(
+							data.dateNextPurchased.toMillis(),
+							data.dateCreated.toMillis(),
+					  )
+					: getDaysBetweenDates(
+							data.dateNextPurchased.toMillis(),
+							data.dateLastPurchased.toMillis(),
+					  );
+
+			//use calculateEstimate to tell the time until next purchase
+			const daysUntilNextPurchase = calculateEstimate(
+				lastEstimatedInterval,
+				timeSinceLastPurchase,
+				data.totalPurchases + 1,
+			);
+
 			const nextData = {
 				dateLastPurchased: new Date(),
 				totalPurchases: data.totalPurchases + 1,
-				// dateNextPurchased: new Date() + getDaysBetweenDates
+				dateNextPurchased: new Date(
+					today.getTime() + daysUntilNextPurchase * ONE_DAY_IN_MILLISECONDS,
+				),
 			};
 
 			updateItem(listToken, data.id, nextData);
 		}
 	};
-
-	const today = new Date();
-
-	// if the item hasn't been purchased, compare today to the date of its creation else compare today to the day it was last purchased.
-	const timeSinceLastPurchase =
-		data.dateLastPurchased === null
-			? getDaysBetweenDates(today.getTime(), data.dateCreated.toMillis())
-			: getDaysBetweenDates(today.getTime(), data.dateLastPurchased.toMillis());
-	console.log(timeSinceLastPurchase);
-
-	//interval last time
-	const lastEstimatedInterval =
-		data.dateLastPurchased === null
-			? getDaysBetweenDates(
-					data.dateNextPurchased.toMillis(),
-					data.dateCreated.toMillis(),
-			  )
-			: getDaysBetweenDates(
-					data.dateNextPurchased.toMillis(),
-					data.dateLastPurchased.toMillis(),
-			  );
-
-	//use calculateEstimate to tell the time until next purchase
-	const daysUntilNextPurchase = calculateEstimate(
-		lastEstimatedInterval,
-		timeSinceLastPurchase,
-		data.totalPurchases + 1,
-	);
-
-	console.log({
-		itemName: data.name,
-		timeSinceLastPurchase,
-		lastEstimatedInterval,
-		daysUntilNextPurchase,
-	});
 
 	return (
 		<>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -43,13 +43,14 @@ export function ListItem({ name, data, listToken }) {
 function createNextData(data) {
 	const today = new Date();
 	const ONE_DAY_IN_MILLISECONDS = 86400000;
-	// if the item hasn't been purchased, compare today to the date of its creation, else compare today to the day it was last purchased.
+
+	// if the item hasn't been purchased: compare today to the date of its creation, else: compare today to the day it was last purchased
 	const timeSinceLastPurchase =
 		data.dateLastPurchased === null
 			? getDaysBetweenDates(today.getTime(), data.dateCreated.toMillis())
 			: getDaysBetweenDates(today.getTime(), data.dateLastPurchased.toMillis());
 
-	//interval last time
+	//if the item hasn't been purchased yet: compare its next purchase date to the date of its creation, else: compare its next purchase date to the date it was last purchased
 	const lastEstimatedInterval =
 		data.dateLastPurchased === null
 			? getDaysBetweenDates(

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -23,6 +23,18 @@ export function ListItem({ name, data, listToken }) {
 
 			updateItem(listToken, data.id, nextData);
 		}
+
+		const today = new Date();
+
+		// if the item hasn't been purchased, compare today to the date of its creation else compare today to the day it was last purchased.
+		const delta =
+			data.dateLastPurchased === null
+				? getDaysBetweenDates(today.getTime(), data.dateCreated.toMillis())
+				: getDaysBetweenDates(
+						today.getTime(),
+						data.dateLastPurchased.toMillis(),
+				  );
+		console.log(delta);
 	};
 
 	return (

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,6 +2,7 @@ import './ListItem.css';
 import { useState } from 'react';
 import { updateItem } from '../api';
 import { getDaysBetweenDates } from '../utils';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 export function ListItem({ name, data, listToken }) {
 	const initialChecked =
@@ -23,19 +24,42 @@ export function ListItem({ name, data, listToken }) {
 
 			updateItem(listToken, data.id, nextData);
 		}
-
-		const today = new Date();
-
-		// if the item hasn't been purchased, compare today to the date of its creation else compare today to the day it was last purchased.
-		const delta =
-			data.dateLastPurchased === null
-				? getDaysBetweenDates(today.getTime(), data.dateCreated.toMillis())
-				: getDaysBetweenDates(
-						today.getTime(),
-						data.dateLastPurchased.toMillis(),
-				  );
-		console.log(delta);
 	};
+
+	const today = new Date();
+
+	// if the item hasn't been purchased, compare today to the date of its creation else compare today to the day it was last purchased.
+	const timeSinceLastPurchase =
+		data.dateLastPurchased === null
+			? getDaysBetweenDates(today.getTime(), data.dateCreated.toMillis())
+			: getDaysBetweenDates(today.getTime(), data.dateLastPurchased.toMillis());
+	console.log(timeSinceLastPurchase);
+
+	//interval last time
+	const lastEstimatedInterval =
+		data.dateLastPurchased === null
+			? getDaysBetweenDates(
+					data.dateNextPurchased.toMillis(),
+					data.dateCreated.toMillis(),
+			  )
+			: getDaysBetweenDates(
+					data.dateNextPurchased.toMillis(),
+					data.dateLastPurchased.toMillis(),
+			  );
+
+	//use calculateEstimate to tell the time until next purchase
+	const daysUntilNextPurchase = calculateEstimate(
+		lastEstimatedInterval,
+		timeSinceLastPurchase,
+		data.totalPurchases + 1,
+	);
+
+	console.log({
+		itemName: data.name,
+		timeSinceLastPurchase,
+		lastEstimatedInterval,
+		daysUntilNextPurchase,
+	});
 
 	return (
 		<>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,6 +1,7 @@
 import './ListItem.css';
 import { useState } from 'react';
 import { updateItem } from '../api';
+import { getDaysBetweenDates } from '../utils';
 
 export function ListItem({ name, data, listToken }) {
 	const initialChecked =
@@ -17,6 +18,7 @@ export function ListItem({ name, data, listToken }) {
 			const nextData = {
 				dateLastPurchased: new Date(),
 				totalPurchases: data.totalPurchases + 1,
+				// dateNextPurchased: new Date() + getDaysBetweenDates
 			};
 
 			updateItem(listToken, data.id, nextData);

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -12,10 +12,7 @@ export function getFutureDate(offset) {
 }
 
 export function getDaysBetweenDates(newerPurchase, olderPurchase) {
-	const newerPurchaseMilliseconds = newerPurchase.toDate().getTime();
-	const olderPurchaseMilliseconds = olderPurchase.toDate().getTime();
-
-	const timeBetween = newerPurchaseMilliseconds - olderPurchaseMilliseconds;
+	const timeBetween = newerPurchase - olderPurchase;
 	const daysBetween = Math.floor(timeBetween / ONE_DAY_IN_MILLISECONDS);
 
 	return daysBetween;

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,8 +11,11 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates(newerPurchase, olderPurchase) {
-	const timeBetween = newerPurchase - olderPurchase;
+export function getDaysBetweenDates(
+	newerPurchaseInMilliseconds,
+	olderPurchaseinMilliseconds,
+) {
+	const timeBetween = newerPurchaseInMilliseconds - olderPurchaseinMilliseconds;
 	const daysBetween = Math.floor(timeBetween / ONE_DAY_IN_MILLISECONDS);
 
 	return daysBetween;

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,13 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(newerPurchase, olderPurchase) {
+	const newerPurchaseMilliseconds = newerPurchase.toDate().getTime();
+	const olderPurchaseMilliseconds = olderPurchase.toDate().getTime();
+
+	const timeBetween = newerPurchaseMilliseconds - olderPurchaseMilliseconds;
+	const daysBetween = Math.floor(timeBetween / ONE_DAY_IN_MILLISECONDS);
+
+	return daysBetween;
+}


### PR DESCRIPTION
## Description

Closes #10 

## Related Issue

## Acceptance Criteria

- [X] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [X] `dateNextPurchased` is saved as **a date**, not a number
- [X] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [X] This function takes two JavaScript Dates and return the number of days that have passed between them

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Testing Steps / QA Criteria
When the user purchases an item, the item’s `dateNextPurchased` property is updated in the Firestore database as a date calculated by the `calculateEstimate` function.