### PR TITLE
Update and add icons to bottom navigation bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@fortawesome/fontawesome-svg-core": "^6.3.0",
+				"@fortawesome/free-solid-svg-icons": "^6.3.0",
+				"@fortawesome/react-fontawesome": "^0.2.0",
 				"@the-collab-lab/shopping-list-utils": "^2.0.0",
 				"firebase": "^9.15.0",
 				"react": "^18.2.0",
@@ -2922,6 +2925,51 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.9.0.tgz",
 			"integrity": "sha512-BpiZLBWdLFw+qFel9p3Zs1jD6QmH7Ii4aTDu6+vx8ShdidChZUXqDhYJly4ZjSgQh54miXbBgBrk0S+jTIh/Qg=="
+		},
+		"node_modules/@fortawesome/fontawesome-common-types": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.3.0.tgz",
+			"integrity": "sha512-4BC1NMoacEBzSXRwKjZ/X/gmnbp/HU5Qqat7E8xqorUtBFZS+bwfGH5/wqOC2K6GV0rgEobp3OjGRMa5fK9pFg==",
+			"hasInstallScript": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/fontawesome-svg-core": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.3.0.tgz",
+			"integrity": "sha512-uz9YifyKlixV6AcKlOX8WNdtF7l6nakGyLYxYaCa823bEBqyj/U2ssqtctO38itNEwXb8/lMzjdoJ+aaJuOdrw==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "6.3.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/free-solid-svg-icons": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.3.0.tgz",
+			"integrity": "sha512-x5tMwzF2lTH8pyv8yeZRodItP2IVlzzmBuD1M7BjawWgg9XAvktqJJ91Qjgoaf8qJpHQ8FEU9VxRfOkLhh86QA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "6.3.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/react-fontawesome": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+			"integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+			"dependencies": {
+				"prop-types": "^15.8.1"
+			},
+			"peerDependencies": {
+				"@fortawesome/fontawesome-svg-core": "~1 || ~6",
+				"react": ">=16.3"
+			}
 		},
 		"node_modules/@grpc/grpc-js": {
 			"version": "1.7.3",
@@ -7621,7 +7669,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8025,7 +8072,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -8035,8 +8081,7 @@
 		"node_modules/prop-types/node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"node_modules/protobufjs": {
 			"version": "6.11.3",
@@ -12062,6 +12107,35 @@
 			"resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.9.0.tgz",
 			"integrity": "sha512-BpiZLBWdLFw+qFel9p3Zs1jD6QmH7Ii4aTDu6+vx8ShdidChZUXqDhYJly4ZjSgQh54miXbBgBrk0S+jTIh/Qg=="
 		},
+		"@fortawesome/fontawesome-common-types": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.3.0.tgz",
+			"integrity": "sha512-4BC1NMoacEBzSXRwKjZ/X/gmnbp/HU5Qqat7E8xqorUtBFZS+bwfGH5/wqOC2K6GV0rgEobp3OjGRMa5fK9pFg=="
+		},
+		"@fortawesome/fontawesome-svg-core": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.3.0.tgz",
+			"integrity": "sha512-uz9YifyKlixV6AcKlOX8WNdtF7l6nakGyLYxYaCa823bEBqyj/U2ssqtctO38itNEwXb8/lMzjdoJ+aaJuOdrw==",
+			"requires": {
+				"@fortawesome/fontawesome-common-types": "6.3.0"
+			}
+		},
+		"@fortawesome/free-solid-svg-icons": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.3.0.tgz",
+			"integrity": "sha512-x5tMwzF2lTH8pyv8yeZRodItP2IVlzzmBuD1M7BjawWgg9XAvktqJJ91Qjgoaf8qJpHQ8FEU9VxRfOkLhh86QA==",
+			"requires": {
+				"@fortawesome/fontawesome-common-types": "6.3.0"
+			}
+		},
+		"@fortawesome/react-fontawesome": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+			"integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+			"requires": {
+				"prop-types": "^15.8.1"
+			}
+		},
 		"@grpc/grpc-js": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
@@ -15529,8 +15603,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
 		},
 		"object-inspect": {
 			"version": "1.12.2",
@@ -15800,7 +15873,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -15810,8 +15882,7 @@
 				"react-is": {
 					"version": "16.13.1",
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-					"dev": true
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@fortawesome/fontawesome-svg-core": "^6.3.0",
+		"@fortawesome/free-solid-svg-icons": "^6.3.0",
+		"@fortawesome/react-fontawesome": "^0.2.0",
 		"@the-collab-lab/shopping-list-utils": "^2.0.0",
 		"firebase": "^9.15.0",
 		"react": "^18.2.0",

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -37,6 +37,7 @@
 .Nav {
 	align-items: stretch;
 	background-color: var(--color-bg);
+	border-top: 3px solid white;
 	bottom: 0;
 	display: flex;
 	flex-direction: row;
@@ -47,7 +48,6 @@
 
 .Nav-link {
 	--color-text: var(--color-accent);
-
 	color: var(--color-text);
 	font-size: 1.45em;
 	flex: 0 1 auto;

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -54,9 +54,20 @@
 	padding: 0.8rem;
 	text-align: center;
 	text-underline-offset: 0.1em;
+	display: table-cell;
+	vertical-align: middle;
 }
 
 .Nav-link.active {
 	text-decoration-thickness: 0.22em;
 	text-underline-offset: 0.1em;
+}
+
+.buttonContainer {
+	display: table;
+	width: 100%;
+}
+
+.buttonContainer .Nav-link span {
+	display: block;
 }

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -71,3 +71,11 @@
 .buttonContainer .Nav-link span {
 	display: block;
 }
+
+.leftNav {
+	border-right: 1.5px solid white;
+}
+
+.rightNav {
+	border-left: 1.5px solid white;
+}

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,5 +1,8 @@
 import { Outlet } from 'react-router-dom';
 import { NavLink } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faListDots } from '@fortawesome/free-solid-svg-icons';
+import { faCartPlus } from '@fortawesome/free-solid-svg-icons';
 
 import './Layout.css';
 
@@ -22,15 +25,18 @@ export function Layout() {
 					<Outlet />
 				</main>
 				<nav className="Nav">
-					<NavLink to="/" className="Nav-link">
-						Home
-					</NavLink>
-					<NavLink to="/list" className="Nav-link">
-						List
-					</NavLink>
-					<NavLink to="add-item" className="Nav-link">
-						Add Item
-					</NavLink>
+					<div className="ListButton">
+						<NavLink to="/list" className="Nav-link">
+							<FontAwesomeIcon icon={faListDots} />
+							List
+						</NavLink>
+					</div>
+					<div className="AddButton">
+						<NavLink to="add-item" className="Nav-link">
+							<FontAwesomeIcon icon={faCartPlus} />
+							Add Item
+						</NavLink>
+					</div>
 				</nav>
 			</div>
 		</>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -25,13 +25,13 @@ export function Layout() {
 					<Outlet />
 				</main>
 				<nav className="Nav">
-					<div className="buttonContainer">
+					<div className="buttonContainer leftNav">
 						<NavLink to="/list" className="Nav-link">
 							<FontAwesomeIcon icon={faListDots} />
 							<span>List</span>
 						</NavLink>
 					</div>
-					<div className="buttonContainer">
+					<div className="buttonContainer rightNav">
 						<NavLink to="add-item" className="Nav-link">
 							<FontAwesomeIcon icon={faCartPlus} />
 							<span>Add Item</span>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -25,16 +25,16 @@ export function Layout() {
 					<Outlet />
 				</main>
 				<nav className="Nav">
-					<div className="ListButton">
+					<div className="buttonContainer">
 						<NavLink to="/list" className="Nav-link">
 							<FontAwesomeIcon icon={faListDots} />
-							List
+							<span>List</span>
 						</NavLink>
 					</div>
-					<div className="AddButton">
+					<div className="buttonContainer">
 						<NavLink to="add-item" className="Nav-link">
 							<FontAwesomeIcon icon={faCartPlus} />
-							Add Item
+							<span>Add Item</span>
 						</NavLink>
 					</div>
 				</nav>


### PR DESCRIPTION
## Description

Creates ubiquitous navigation buttons at the bottom of each page directing users either to the List or Add Item page.  Removes "Home" option.  Icons were added alongside text for each button.  

## Related Issue



## Acceptance Criteria

-Implement decided on styling theme for the navigation bar

## Type of Changes


|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

Nav bar had default "Home", "List", "Add Item" unstyled links

### After

Removed option for "Home" and added icons with the text for "List" and "Add Item" nav links as well as borders

## Testing Steps / QA Criteria


