### PR TITLE
Add current list token to list page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,9 +24,26 @@ export function App() {
 		'tcl-shopping-list-token',
 	);
 
+	// Create/get a history of list tokens used so we can show the user all the lists they've ever viewed and jump between them.
+	const [tokenHistory, setTokenHistory] = useStateWithStorage(
+		[],
+		'tcl-shopping-list-token-history',
+	);
+
+	// Check if the token exists in the token history but has not been migrated there, and if not, add it.
+	if (listToken && !tokenHistory.includes(listToken)) {
+		setTokenHistory([...tokenHistory, listToken]);
+	}
+	// check if token history is an array, and if not, convert it to an array.
+	if (!Array.isArray(tokenHistory)) {
+		setTokenHistory([tokenHistory]);
+	}
+
 	const handleNewToken = () => {
 		const newToken = generateToken();
 		setListToken(newToken);
+		// Add the new token to the token history
+		setTokenHistory([...tokenHistory, newToken]);
 	};
 
 	useEffect(() => {
@@ -64,12 +81,19 @@ export function App() {
 								handleNewToken={handleNewToken}
 								setListToken={setListToken}
 								listToken={listToken}
+								tokenHistory={tokenHistory}
 							/>
 						}
 					/>
 					<Route
 						path="/list"
-						element={<List data={data} listToken={listToken} />}
+						element={
+							<List
+								data={data}
+								listToken={listToken}
+								tokenHistory={tokenHistory}
+							/>
+						}
 					/>
 					<Route
 						path="/add-item"

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -3,7 +3,12 @@ import { useCallback, useState } from 'react';
 import { checkListToken } from '../api/firebase';
 import { useNavigate } from 'react-router-dom';
 
-export function Home({ handleNewToken, setListToken, listToken }) {
+export function Home({
+	handleNewToken,
+	setListToken,
+	listToken,
+	tokenHistory,
+}) {
 	const [token, setToken] = useState('');
 	const [listNotFound, setlistNotFound] = useState('');
 	const redirect = useNavigate();
@@ -40,6 +45,24 @@ export function Home({ handleNewToken, setListToken, listToken }) {
 				Hello from the home (<code>/</code>) page.
 			</p>
 			<button onClick={handleClick}>Create a new list!</button>
+
+			<p> Here are your previous lists</p>
+			<ul>
+				{tokenHistory.map((token) => {
+					return (
+						<li key={token}>
+							<button
+								onClick={() => {
+									setListToken(token);
+									redirect('/list');
+								}}
+							>
+								{token}
+							</button>
+						</li>
+					);
+				})}
+			</ul>
 			<p> Want to join an existing list? </p>
 			<form onSubmit={handleTokenSubmit}>
 				<label htmlFor="token"> Enter Token:</label>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -18,6 +18,8 @@ export function List({ data, listToken }) {
 		setSearchedItem('');
 	}
 
+	const currentList = listToken;
+
 	return (
 		<>
 			{/* welcome people to add to their list if it's empty */}
@@ -33,9 +35,10 @@ export function List({ data, listToken }) {
 					</NavLink>
 				</div>
 			) : (
-				// otherwise show people their list
+				// otherwise show people their by collection name
 				<div>
-					<h1>Welcome back!</h1>
+					<h1>Welcome back to your list!</h1>
+					<h2>Your secret token is: {currentList}</h2>
 					<form>
 						<label htmlFor="filter">Filter Items:</label>
 						<input

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -2,7 +2,7 @@ import { ListItem } from '../components';
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
-export function List({ data, listToken }) {
+export function List({ data, listToken, tokenHistory }) {
 	//set state
 	const [searchedItem, setSearchedItem] = useState('');
 	//filtering items searched
@@ -39,6 +39,12 @@ export function List({ data, listToken }) {
 				<div>
 					<h1>Welcome back to your list!</h1>
 					<h2>Your secret token is: {currentList}</h2>
+					<span>Token History</span>
+					<ul>
+						{tokenHistory.map((token) => {
+							return <li key={token}>{token}</li>;
+						})}
+					</ul>
 					<form>
 						<label htmlFor="filter">Filter Items:</label>
 						<input


### PR DESCRIPTION
## Description

One function of the app is to be able to share lists across users, which are identified with list tokens.  This allows users to clearly see their list token, which they would otherwise be unable to do without using dev tools.

## Related
Closes #31 

## Acceptance Criteria

- [x] List token is clearly labeled and visible for users to share.

## Type of Changes

List token was added to h1 of list page.

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates
### Before
![list token isn't visible](https://user-images.githubusercontent.com/86696232/221967628-1e71d1e5-0cf5-43e2-9ea6-56737ae30038.png)

### After
![list token is showing](https://user-images.githubusercontent.com/86696232/221966788-c7483e2b-3d98-4cc2-99c1-8731ba38dd83.png)

## Testing Steps / QA Criteria

Check between other lists, clear your local memory and make a new one.
